### PR TITLE
Make the SimpleDateFormat parse dates expressed in UTC-00:00:00.

### DIFF
--- a/src/source/ReactNativeJavaGenerator.scala
+++ b/src/source/ReactNativeJavaGenerator.scala
@@ -374,7 +374,7 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
         wr.wl(s"String $converted = byteArrayToHexString($converting);")
       }
       case MDate => {
-        wr.wl(s"""DateFormat ${converting}DateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");""")
+        wr.wl(s"""DateFormat ${converting}DateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");""")
         wr.wl(s"String $converted = ${converting}DateFormat.format($converting);")
       }
       case d: MDef =>
@@ -637,7 +637,7 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
 
     });
   }
-  
+
   def addDefaultReferences(references: ReactNativeRefs): Unit = {
     references.java.add("java.util.ArrayList")
     references.java.add("java.util.HashMap")
@@ -847,7 +847,7 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
                           case _ => converting
                         }
                       case MDate => {
-                        w.wl("""DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");""")
+                        w.wl("""DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");""")
                         w.wl(s"String finalJavaResult = dateFormat.format($converting);")
                         "finalJavaResult"
                       }


### PR DESCRIPTION
The previous fix that removes the Z is commit 0e282651. I still don’t
get why nor what it was trying to fix. AFAIK, when a PARSER receives an
input string that contains a Z (i.e. stands for Zulu time), it means
that it HAS to interpret the time as UTC-00:00:00. If the Z is not
present, we can make no assumption on how the parser will interpret the
time and it’s very likely that it will try to use its own locale to
deduce the timezone to resolve.

LLC-170