### PR TITLE
Fix illegal callback invocation from native module.

### DIFF
--- a/src/source/ReactNativeJavaGenerator.scala
+++ b/src/source/ReactNativeJavaGenerator.scala
@@ -637,7 +637,7 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
 
     });
   }
-  
+
   def addDefaultReferences(references: ReactNativeRefs): Unit = {
     references.java.add("java.util.ArrayList")
     references.java.add("java.util.HashMap")
@@ -811,13 +811,15 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
                 w.wl(s"if ($errorParamField != null && $errorParamField.getMessage().length() > 0)").braced {
                   w.wl(s"this.promise.reject(${idJava.field(errorParam.ident)}.toString(), $errorParamField.getMessage());")
                 }
-                val resultParam = m.params(0)
-                val isParamInterface = isExprInterface(resultParam.ty.resolved)
-                val isParamRecord = isExprRecord(resultParam.ty.resolved)
-                val isParamBinary = isBinary(resultParam.ty.resolved)
-                toReactType(resultParam.ty.resolved, "converted_result", idJava.field(resultParam.ident), w)
-                w.wl
-                w.wl(s"this.promise.resolve(${if (isParamInterface || isParamRecord || isParamBinary) "converted_result" else idJava.field(resultParam.ident)});")
+                w.wl(s"else").braced {
+                  val resultParam = m.params(0)
+                  val isParamInterface = isExprInterface(resultParam.ty.resolved)
+                  val isParamRecord = isExprRecord(resultParam.ty.resolved)
+                  val isParamBinary = isBinary(resultParam.ty.resolved)
+                  toReactType(resultParam.ty.resolved, "converted_result", idJava.field(resultParam.ident), w)
+                  w.wl
+                  w.wl(s"this.promise.resolve(${if (isParamInterface || isParamRecord || isParamBinary) "converted_result" else idJava.field(resultParam.ident)});")
+                }
               }
 
 


### PR DESCRIPTION
# Context

Android devices reported several illegal callback invocations from native modules lately, due to a double-call of promises in native-based code, always in the [same file](https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings/blob/master/android/src/main/java/com/ledger/reactnative/RCTCoreOperationListCallback.java#L72) and always with a rejecting promise.

In this file, we can see that the `if` statement, when active, will make the promise reject, but the control flow of the `onCallback` method doesn’t stop and goes on, executing a useless loop and trying to resolve the callback, yielding a second call.

# Solution

This fix wraps the rest of the code in an `else` statement so that no double call is possible in that callback.

# Rationale

This is happening (in the sentry entries) in `RCTCoreOperationListCallback` but in theory, it could happen with any kind of callback.