### PR TITLE
Add IDL support for callbacks.

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -169,11 +169,11 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           case DRecord => withNamespace(idCpp.ty(d.name))
           case DInterface => s"std::shared_ptr<${withNamespace(idCpp.ty(d.name))}>"
         }
-        case e: MExtern => e.defType match {
-          case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
-          case _ => e.cpp.typename
-        }
-        case p: MParam => idCpp.typeParam(p.name)
+      case e: MExtern => e.defType match {
+        case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
+        case _ => e.cpp.typename
+      }
+      case p: MParam => idCpp.typeParam(p.name)
     }
     def expr(tm: MExpr): String = {
       spec.cppNnType match {

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -53,6 +53,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
       case "i8" | "i16" | "i32" | "i64" => List(ImportRef("<cstdint>"))
       case _ => List()
     }
+    case MVoid => List()
     case MString => List(ImportRef("<string>"))
     case MDate => List(ImportRef("<chrono>"))
     case MBinary => List(ImportRef("<vector>"), ImportRef("<cstdint>"))
@@ -153,6 +154,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     }
     def base(m: Meta): String = m match {
       case p: MPrimitive => p.cName
+      case MVoid => "void"
       case MString => if (spec.cppUseWideStrings) "std::wstring" else "std::string"
       case MDate => "std::chrono::system_clock::time_point"
       case MBinary => "std::vector<uint8_t>"

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -207,10 +207,19 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           // ensure it’s not a callback type, which has the function-type notation
           val args = tm.base match {
             // it’s a callback, so the type in brackets need to have the return type before
-            // the actual list of arguments
+            // the actual list of arguments; the first argument is the return type
             case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6
                | MCallback7 | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12
-               | MCallback13 | MCallback14 | MCallback15 => tm.args.map(expr).mkString("<void(", ", ", ")>")
+               | MCallback13 | MCallback14 | MCallback15 => {
+              if (tm.args.isEmpty) {
+                ""
+              } else {
+                // get the first element as return value of the callback
+                val args = tm.args.map(expr)
+                val first = args.head.mkString("<", "", "(")
+                args.tail.mkString(first, ", ", ")>")
+              }
+            }
             case _ => if (tm.args.isEmpty) "" else tm.args.map(expr).mkString("<", ", ", ">")
           }
           base(tm.base) + args

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -169,11 +169,11 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           case DRecord => withNamespace(idCpp.ty(d.name))
           case DInterface => s"std::shared_ptr<${withNamespace(idCpp.ty(d.name))}>"
         }
-      case e: MExtern => e.defType match {
-        case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
-        case _ => e.cpp.typename
-      }
-      case p: MParam => idCpp.typeParam(p.name)
+        case e: MExtern => e.defType match {
+          case DInterface => s"std::shared_ptr<${e.cpp.typename}>"
+          case _ => e.cpp.typename
+        }
+        case p: MParam => idCpp.typeParam(p.name)
     }
     def expr(tm: MExpr): String = {
       spec.cppNnType match {
@@ -204,7 +204,15 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           // otherwise, interfaces are always plain old shared_ptr
           expr(tm.args.head)
         } else {
-          val args = if (tm.args.isEmpty) "" else tm.args.map(expr).mkString("<", ", ", ">")
+          // ensure it’s not a callback type, which has the function-type notation
+          val args = tm.base match {
+            // it’s a callback, so the type in brackets need to have the return type before
+            // the actual list of arguments
+            case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6
+               | MCallback7 | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12
+               | MCallback13 | MCallback14 | MCallback15 => tm.args.map(expr).mkString("<void(", ", ", ")>")
+            case _ => if (tm.args.isEmpty) "" else tm.args.map(expr).mkString("<", ", ", ">")
+          }
           base(tm.base) + args
         }
       }

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -160,6 +160,9 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
       case MList => "std::vector"
       case MSet => "std::unordered_set"
       case MMap => "std::unordered_map"
+      case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6
+         | MCallback7 | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12
+         | MCallback13 | MCallback14 | MCallback15 => "std::function"
       case d: MDef =>
         d.defType match {
           case DEnum => withNamespace(idCpp.enumType(d.name))

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -60,6 +60,9 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case MList => List(ImportRef("<vector>"))
     case MSet => List(ImportRef("<unordered_set>"))
     case MMap => List(ImportRef("<unordered_map>"))
+    case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6 | MCallback7
+       | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12 | MCallback13
+       | MCallback14 | MCallback15 => List(ImportRef("<functional>"))
     case d: MDef => d.body match {
       case r: Record =>
         if (d.name != exclude) {

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -77,6 +77,7 @@ case object DInterface extends DefType
 case object DRecord extends DefType
 
 case class MPrimitive(_idlName: String, jName: String, jniName: String, cName: String, jBoxed: String, jSig: String, objcName: String, objcBoxed: String, swiftName: String, nodeJSName: String, jsName: String) extends MOpaque { val numParams = 0; val idlName = _idlName }
+case object MVoid extends MOpaque { val numParams = 0; val idlName = "void" }
 case object MString extends MOpaque { val numParams = 0; val idlName = "string" }
 case object MDate extends MOpaque { val numParams = 0; val idlName = "date" }
 case object MBinary extends MOpaque { val numParams = 0; val idlName = "binary" }
@@ -108,6 +109,7 @@ val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("f32",  MPrimitive("f32",  "float",   "jfloat",   "float",   "Float",   "F", "float",   "NSNumber", "Float32", "Number", "number")),
   ("f64",  MPrimitive("f64",  "double",  "jdouble",  "double",  "Double",  "D", "double",  "NSNumber", "Float64", "Number", "number")),
   ("bool", MPrimitive("bool", "boolean", "jboolean", "bool",    "Boolean", "Z", "BOOL",    "NSNumber", "Bool", "Boolean", "boolean")),
+  ("void", MVoid),
   ("string", MString),
   ("binary", MBinary),
   ("optional", MOptional),

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -115,20 +115,20 @@ val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("list", MList),
   ("set", MSet),
   ("map", MMap),
-  ("callback1", MCallback1)
-  ("callback2", MCallback2)
-  ("callback3", MCallback3)
-  ("callback4", MCallback4)
-  ("callback5", MCallback5)
-  ("callback6", MCallback6)
-  ("callback7", MCallback7)
-  ("callback8", MCallback8)
-  ("callback9", MCallback9)
-  ("callback10", MCallback10)
-  ("callback11", MCallback11)
-  ("callback12", MCallback12)
-  ("callback13", MCallback13)
-  ("callback14", MCallback14)
+  ("callback1", MCallback1),
+  ("callback2", MCallback2),
+  ("callback3", MCallback3),
+  ("callback4", MCallback4),
+  ("callback5", MCallback5),
+  ("callback6", MCallback6),
+  ("callback7", MCallback7),
+  ("callback8", MCallback8),
+  ("callback9", MCallback9),
+  ("callback10", MCallback10),
+  ("callback11", MCallback11),
+  ("callback12", MCallback12),
+  ("callback13", MCallback13),
+  ("callback14", MCallback14),
   ("callback15", MCallback15)
 )
 

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -84,21 +84,21 @@ case object MOptional extends MOpaque { val numParams = 1; val idlName = "option
 case object MList extends MOpaque { val numParams = 1; val idlName = "list" }
 case object MSet extends MOpaque { val numParams = 1; val idlName = "set" }
 case object MMap extends MOpaque { val numParams = 2; val idlName = "map" }
-case object MCallback1 extends MOpaque { val numParams = 1; val idlName = "callback1" }
-case object MCallback2 extends MOpaque { val numParams = 2; val idlName = "callback2" }
-case object MCallback3 extends MOpaque { val numParams = 3; val idlName = "callback3" }
-case object MCallback4 extends MOpaque { val numParams = 4; val idlName = "callback4" }
-case object MCallback5 extends MOpaque { val numParams = 5; val idlName = "callback5" }
-case object MCallback6 extends MOpaque { val numParams = 6; val idlName = "callback6" }
-case object MCallback7 extends MOpaque { val numParams = 7; val idlName = "callback7" }
-case object MCallback8 extends MOpaque { val numParams = 8; val idlName = "callback8" }
-case object MCallback9 extends MOpaque { val numParams = 9; val idlName = "callback9" }
-case object MCallback10 extends MOpaque { val numParams = 10; val idlName = "callback10" }
-case object MCallback11 extends MOpaque { val numParams = 11; val idlName = "callback11" }
-case object MCallback12 extends MOpaque { val numParams = 12; val idlName = "callback12" }
-case object MCallback13 extends MOpaque { val numParams = 13; val idlName = "callback13" }
-case object MCallback14 extends MOpaque { val numParams = 14; val idlName = "callback14" }
-case object MCallback15 extends MOpaque { val numParams = 15; val idlName = "callback15" }
+case object MCallback1 extends MOpaque { val numParams = 2; val idlName = "callback1" }
+case object MCallback2 extends MOpaque { val numParams = 3; val idlName = "callback2" }
+case object MCallback3 extends MOpaque { val numParams = 4; val idlName = "callback3" }
+case object MCallback4 extends MOpaque { val numParams = 5; val idlName = "callback4" }
+case object MCallback5 extends MOpaque { val numParams = 6; val idlName = "callback5" }
+case object MCallback6 extends MOpaque { val numParams = 7; val idlName = "callback6" }
+case object MCallback7 extends MOpaque { val numParams = 8; val idlName = "callback7" }
+case object MCallback8 extends MOpaque { val numParams = 9; val idlName = "callback8" }
+case object MCallback9 extends MOpaque { val numParams = 10; val idlName = "callback9" }
+case object MCallback10 extends MOpaque { val numParams = 11; val idlName = "callback10" }
+case object MCallback11 extends MOpaque { val numParams = 12; val idlName = "callback11" }
+case object MCallback12 extends MOpaque { val numParams = 13; val idlName = "callback12" }
+case object MCallback13 extends MOpaque { val numParams = 14; val idlName = "callback13" }
+case object MCallback14 extends MOpaque { val numParams = 15; val idlName = "callback14" }
+case object MCallback15 extends MOpaque { val numParams = 16; val idlName = "callback15" }
 
 val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("i8",   MPrimitive("i8",   "byte",    "jbyte",    "int8_t",  "Byte",    "B", "int8_t",  "NSNumber", "Int8", "Int32", "number")),

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -84,6 +84,21 @@ case object MOptional extends MOpaque { val numParams = 1; val idlName = "option
 case object MList extends MOpaque { val numParams = 1; val idlName = "list" }
 case object MSet extends MOpaque { val numParams = 1; val idlName = "set" }
 case object MMap extends MOpaque { val numParams = 2; val idlName = "map" }
+case object MCallback1 extends MOpaque { val numParams = 1; val idlName = "callback1" }
+case object MCallback2 extends MOpaque { val numParams = 2; val idlName = "callback2" }
+case object MCallback3 extends MOpaque { val numParams = 3; val idlName = "callback3" }
+case object MCallback4 extends MOpaque { val numParams = 4; val idlName = "callback4" }
+case object MCallback5 extends MOpaque { val numParams = 5; val idlName = "callback5" }
+case object MCallback6 extends MOpaque { val numParams = 6; val idlName = "callback6" }
+case object MCallback7 extends MOpaque { val numParams = 7; val idlName = "callback7" }
+case object MCallback8 extends MOpaque { val numParams = 8; val idlName = "callback8" }
+case object MCallback9 extends MOpaque { val numParams = 9; val idlName = "callback9" }
+case object MCallback10 extends MOpaque { val numParams = 10; val idlName = "callback10" }
+case object MCallback11 extends MOpaque { val numParams = 11; val idlName = "callback11" }
+case object MCallback12 extends MOpaque { val numParams = 12; val idlName = "callback12" }
+case object MCallback13 extends MOpaque { val numParams = 13; val idlName = "callback13" }
+case object MCallback14 extends MOpaque { val numParams = 14; val idlName = "callback14" }
+case object MCallback15 extends MOpaque { val numParams = 15; val idlName = "callback15" }
 
 val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("i8",   MPrimitive("i8",   "byte",    "jbyte",    "int8_t",  "Byte",    "B", "int8_t",  "NSNumber", "Int8", "Int32", "number")),
@@ -99,7 +114,23 @@ val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("date", MDate),
   ("list", MList),
   ("set", MSet),
-  ("map", MMap))
+  ("map", MMap),
+  ("callback1", MCallback1)
+  ("callback2", MCallback2)
+  ("callback3", MCallback3)
+  ("callback4", MCallback4)
+  ("callback5", MCallback5)
+  ("callback6", MCallback6)
+  ("callback7", MCallback7)
+  ("callback8", MCallback8)
+  ("callback9", MCallback9)
+  ("callback10", MCallback10)
+  ("callback11", MCallback11)
+  ("callback12", MCallback12)
+  ("callback13", MCallback13)
+  ("callback14", MCallback14)
+  ("callback15", MCallback15)
+)
 
 def isInterface(ty: MExpr): Boolean = {
   ty.base match {


### PR DESCRIPTION
This change adds support for callbacks with arguments (from 1 to 15 arguments; that should be more than enough).

The syntax is pretty simple:

    callbackN<ret_type, args...>

So, `callback1` is a type of callback that takes one value as argument; `callback2` takes two, etc.

    callback1<i32, string> // translates to C++ std::function<int32_t(std::string)>
    callback2<void, i32, bool> // translates to C++ std::function<void(int32_t, bool)>

Also, this PR adds the `void` opaque type.