### PR TITLE
Fix build with node v10.15.1

### DIFF
--- a/src/source/NodeJsCppGenerator.scala
+++ b/src/source/NodeJsCppGenerator.scala
@@ -155,7 +155,7 @@ class NodeJsCppGenerator(spec: Spec, helperFiles: NodeJsHelperFilesDescriptor) e
             if(!m.static) {
               w.wl
               w.wl("//Unwrap current object and retrieve its Cpp Implementation")
-              w.wl(s"auto cpp_impl = djinni::js::ObjectWrapper<$cppClassName>::Unwrap(info.This());")
+              w.wl(s"auto cpp_impl = djinni::js::ObjectWrapper<${spec.cppNamespace}::$cppClassName>::Unwrap(info.This());")
 
               //Test if implementation is null
               w.wl(s"if(!cpp_impl)").braced {
@@ -171,7 +171,7 @@ class NodeJsCppGenerator(spec: Spec, helperFiles: NodeJsHelperFilesDescriptor) e
               if(!m.static) {
                 w.wl(s"auto result = cpp_impl->$methodName($args);")
               } else {
-                w.wl(s"auto result = ${idCpp.ty(ident.name)}::$methodName($args);")
+                w.wl(s"auto result = ${spec.cppNamespace}::${idCpp.ty(ident.name)}::$methodName($args);")
               }
 
               w.wl
@@ -216,7 +216,7 @@ class NodeJsCppGenerator(spec: Spec, helperFiles: NodeJsHelperFilesDescriptor) e
     val baseClassName = marshal.typename(ident, i)
     val cppClassName = cppMarshal.typename(ident, i)
     wr.w(s"NAN_METHOD($baseClassName::isNull)").braced {
-      wr.wl(s"auto cpp_implementation = djinni::js::ObjectWrapper<$cppClassName>::Unwrap(info.This());")
+      wr.wl(s"auto cpp_implementation = djinni::js::ObjectWrapper<${spec.cppNamespace}::$cppClassName>::Unwrap(info.This());")
       wr.wl("auto isNull = !cpp_implementation ? true : false;")
       wr.wl("return info.GetReturnValue().Set(Nan::New<Boolean>(isNull));")
     }

--- a/src/source/NodeJsGenerator.scala
+++ b/src/source/NodeJsGenerator.scala
@@ -41,7 +41,7 @@ class NodeJsGenerator(spec: Spec, helperFiles: NodeJsHelperFilesDescriptor) exte
 
           val ret = cppMarshal.returnType(m.ret)
           val methodName = m.ident.name
-          val params = m.params.map(p => cppMarshal.paramType(p.ty.resolved) + " " + idNode.local(p.ident))
+          val params = m.params.map(p => cppMarshal.fqParamType(p.ty.resolved) + " " + idNode.local(p.ident))
           if (!m.static) {
             val constFlag = if (m.const) " const" else ""
             w.wl
@@ -252,7 +252,7 @@ class NodeJsGenerator(spec: Spec, helperFiles: NodeJsHelperFilesDescriptor) exte
             for (m <- i.methods) {
               val ret = cppMarshal.returnType(m.ret)
               val methodName = m.ident.name
-              val params = m.params.map(p => cppMarshal.paramType(p.ty.resolved) + " " + idNode.local(p.ident))
+              val params = m.params.map(p => cppMarshal.fqParamType(p.ty.resolved) + " " + idNode.local(p.ident))
               if (!m.static) {
                 val constFlag = if (m.const) " const" else ""
                 w.wl

--- a/src/source/NodeJsMarshal.scala
+++ b/src/source/NodeJsMarshal.scala
@@ -335,7 +335,7 @@ class NodeJsMarshal(spec: Spec) extends CppMarshal(spec) {
               }
             } else {
               wr.wl(s"Local<Object> njs_$converted = $converting->ToObject(Nan::GetCurrentContext()).ToLocalChecked();")
-              wr.wl(s"auto $converted = djinni::js::ObjectWrapper<$interfaceName>::Unwrap(njs_$converted);");
+              wr.wl(s"auto $converted = djinni::js::ObjectWrapper<${spec.cppNamespace}::$interfaceName>::Unwrap(njs_$converted);");
 
               if(i.ext.cpp){
                 wr.wl(s"if(!$converted)").braced{


### PR DESCRIPTION
Prefix methods' and interfaces' names with namespace to avoid conflicts, here in `10.15.1`  conflict occurs with `BigInt`