### PR TITLE
[Android] fix for React Native 0.61

### DIFF
--- a/src/source/ReactNativeJavaGenerator.scala
+++ b/src/source/ReactNativeJavaGenerator.scala
@@ -962,7 +962,6 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
             w.wl("super(reactContext);")
             w.wl("this.reactContext = reactContext;")
             w.wl(s"this.javaObjects = new HashMap<String, $javaInterface>();")
-            w.wl("WritableNativeMap.setUseNativeAccessor(true);")
           }
           w.wl
           w.wl("@Override")
@@ -1049,7 +1048,6 @@ class ReactNativeJavaGenerator(spec: Spec, javaInterfaces : Seq[String]) extends
           w.wl("super(reactContext);")
           w.wl("this.reactContext = reactContext;")
           w.wl(s"this.javaObjects = new HashMap<String, $javaInterface>();")
-          w.wl("WritableNativeMap.setUseNativeAccessor(true);")
           if (hasOneFieldAsInterface) {
             w.wl(s"this.implementationsData = new WritableNativeMap();")
           }


### PR DESCRIPTION
Removed calls to `WritableNativeMap.setUseNativeAccessor` which has been [removed from React Native](https://github.com/facebook/react-native/commit/b257e06bc6c29236a1a19f645fb46b85b2ffc4d2).

AFAICT it was some private API which was used as a workaround by third party libs to a bug in older React Native versions, so this shouldn't bring any issue 🤞

### Context

I first naively did the changes in the resulting java files in LedgerHQ/lib-ledger-core-react-native-bindings#37 which allowed me to verify that it seems to be working.

### Caveat

![image](https://user-images.githubusercontent.com/13920153/67783787-10b12400-fa6b-11e9-82e1-cbf481ffd132.png)

