### PR TITLE
Scala Array to java ArrayList conversion 

### DIFF
--- a/src/source/ScalaImplicitsGenerator.scala
+++ b/src/source/ScalaImplicitsGenerator.scala
@@ -72,7 +72,7 @@ class ScalaImplicitsGenerator(spec: Spec) extends Generator(spec) {
             }
           }
         }
-        w.wl("private def arrayList2Array[T](a: Array[T]): java.util.ArrayList[T] = new java.util.ArrayList[T](a.toSeq.asInstanceOf[java.util.Collection[T]])")
+        w.wl("private def arrayList2Array[T](a: Array[T]): java.util.ArrayList[T] = new java.util.ArrayList[T](a.toList.asJava.asInstanceOf[java.util.Collection[T]])")
         for (td <- idl.collect { case itd: InternTypeDecl => itd }) td.body match {
           case i: Interface => generateRichInterface(td.origin, td.ident, td.doc, td.params, i, w)
           case others => // Do nothing


### PR DESCRIPTION
Fix ClassCastException scala.collection.mutable.WrappedArray cannot be cast to java.util.Collection issue

This issue can be reproduced by addressing function with `scala.Array[_root_.scala.Predef.String]`argument exposed by core lib. This will lead to a ClassCastException when ScalaImplicitsGenerator will try to bind from scala to java List type (arrayList2Array function). the bug is due to the fact that a java array is not part of java.util.Collection family.

This PR fix issue encountered on Client Side while providing Array[T] scala type to cpp libcore JNI interface generated by djini just by passing from scala Seq to scala List cast path.

**Stack generated :**

``` [info] 2019-12-06 13:41:08,909 scala-execution-context-global-992 TraceId=a9a3662f9685a813 CorrelationId= [ERROR] ThrowableExceptionMapper : Unhandled Exception
[info] java.lang.ClassCastException: scala.collection.mutable.WrappedArray$ofRef cannot be cast to java.util.Collection
[info] 	at co.ledger.core.implicits.package$.co$ledger$core$implicits$package$$arrayList2Array(package.scala:133)
[info] 	at co.ledger.core.implicits.package$RichEthereumLikeAccount.getERC20Balances(package.scala:857)
[info] 	at co.ledger.wallet.daemon.models.Account$RichCoreAccount$.erc20Balances$extension(Account.scala:41)
[info] 	at co.ledger.wallet.daemon.services.AccountsService.$anonfun$getTokenAccounts$2(AccountsService.scala:191)
[info] 	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
[info] 	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
[info] 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
[info] 	at co.ledger.wallet.daemon.async.MDCPropagatingExecutionContext$$anon$1.$anonfun$execute$1(MDCPropagatingExecutionContext.scala:27)
[info] 	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
[info] 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[info] 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[info] 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[info] 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[info] 2019-12-06 13:41:08,917 scala-execution-context-global-992 TraceId=a9a3662f9685a813 CorrelationId= [WARN] ResponseBuilder : Request Failure: Internal/Unhandled/java.lang.ClassCastException```