### PR TITLE
Fix all implementations of the callback2 type.

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -61,9 +61,6 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case MList => List(ImportRef("<vector>"))
     case MSet => List(ImportRef("<unordered_set>"))
     case MMap => List(ImportRef("<unordered_map>"))
-    case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6 | MCallback7
-       | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12 | MCallback13
-       | MCallback14 | MCallback15 => List(ImportRef("<functional>"))
     case d: MDef => d.body match {
       case r: Record =>
         if (d.name != exclude) {
@@ -162,9 +159,6 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
       case MList => "std::vector"
       case MSet => "std::unordered_set"
       case MMap => "std::unordered_map"
-      case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6
-         | MCallback7 | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12
-         | MCallback13 | MCallback14 | MCallback15 => "std::function"
       case d: MDef =>
         d.defType match {
           case DEnum => withNamespace(idCpp.enumType(d.name))
@@ -206,24 +200,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
           // otherwise, interfaces are always plain old shared_ptr
           expr(tm.args.head)
         } else {
-          // ensure it’s not a callback type, which has the function-type notation
-          val args = tm.base match {
-            // it’s a callback, so the type in brackets need to have the return type before
-            // the actual list of arguments; the first argument is the return type
-            case MCallback1 | MCallback2 | MCallback3 | MCallback4 | MCallback5 | MCallback6
-               | MCallback7 | MCallback8 | MCallback9 | MCallback10 | MCallback11 | MCallback12
-               | MCallback13 | MCallback14 | MCallback15 => {
-              if (tm.args.isEmpty) {
-                ""
-              } else {
-                // get the first element as return value of the callback
-                val args = tm.args.map(expr)
-                val first = args.head.mkString("<", "", "(")
-                args.tail.mkString(first, ", ", ")>")
-              }
-            }
-            case _ => if (tm.args.isEmpty) "" else tm.args.map(expr).mkString("<", ", ", ">")
-          }
+          val args = if (tm.args.isEmpty) "" else tm.args.map(expr).mkString("<", ", ", ">")
           base(tm.base) + args
         }
       }

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -16,7 +16,7 @@
 
 package djinni
 
-import djinni.ast.TypeDef
+import djinni.ast.{Interface, TypeDef}
 import scala.collection.immutable
 
 package object meta {
@@ -85,21 +85,6 @@ case object MOptional extends MOpaque { val numParams = 1; val idlName = "option
 case object MList extends MOpaque { val numParams = 1; val idlName = "list" }
 case object MSet extends MOpaque { val numParams = 1; val idlName = "set" }
 case object MMap extends MOpaque { val numParams = 2; val idlName = "map" }
-case object MCallback1 extends MOpaque { val numParams = 2; val idlName = "callback1" }
-case object MCallback2 extends MOpaque { val numParams = 3; val idlName = "callback2" }
-case object MCallback3 extends MOpaque { val numParams = 4; val idlName = "callback3" }
-case object MCallback4 extends MOpaque { val numParams = 5; val idlName = "callback4" }
-case object MCallback5 extends MOpaque { val numParams = 6; val idlName = "callback5" }
-case object MCallback6 extends MOpaque { val numParams = 7; val idlName = "callback6" }
-case object MCallback7 extends MOpaque { val numParams = 8; val idlName = "callback7" }
-case object MCallback8 extends MOpaque { val numParams = 9; val idlName = "callback8" }
-case object MCallback9 extends MOpaque { val numParams = 10; val idlName = "callback9" }
-case object MCallback10 extends MOpaque { val numParams = 11; val idlName = "callback10" }
-case object MCallback11 extends MOpaque { val numParams = 12; val idlName = "callback11" }
-case object MCallback12 extends MOpaque { val numParams = 13; val idlName = "callback12" }
-case object MCallback13 extends MOpaque { val numParams = 14; val idlName = "callback13" }
-case object MCallback14 extends MOpaque { val numParams = 15; val idlName = "callback14" }
-case object MCallback15 extends MOpaque { val numParams = 16; val idlName = "callback15" }
 
 val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("i8",   MPrimitive("i8",   "byte",    "jbyte",    "int8_t",  "Byte",    "B", "int8_t",  "NSNumber", "Int8", "Int32", "number")),
@@ -116,27 +101,19 @@ val defaults: Map[String,MOpaque] = immutable.HashMap(
   ("date", MDate),
   ("list", MList),
   ("set", MSet),
-  ("map", MMap),
-  ("callback1", MCallback1),
-  ("callback2", MCallback2),
-  ("callback3", MCallback3),
-  ("callback4", MCallback4),
-  ("callback5", MCallback5),
-  ("callback6", MCallback6),
-  ("callback7", MCallback7),
-  ("callback8", MCallback8),
-  ("callback9", MCallback9),
-  ("callback10", MCallback10),
-  ("callback11", MCallback11),
-  ("callback12", MCallback12),
-  ("callback13", MCallback13),
-  ("callback14", MCallback14),
-  ("callback15", MCallback15)
+  ("map", MMap)
 )
 
 def isInterface(ty: MExpr): Boolean = {
   ty.base match {
-    case d: MDef => d.defType == DInterface
+    case d: MDef => d.defType == DInterface || (d.body match {
+      case _: Interface => true
+      case _ => false
+    })
+    case d: MExtern => d.defType == DInterface || (d.body match {
+      case _: Interface => true
+      case _ => false
+    })
     case _ => false
   }
 }


### PR DESCRIPTION
- Remove all MCallback*. The `callback2` type now only exists as a
  preprocessor concept (in the same way `Callback` exists only as a
  preprocessor idea.
- The biggest impact of this commit is that ALL implementations are fixed (not
  only JNI / JS, but everything.
- The not-so-great impact is that the `Callback` and `ListCallback` type
  make a return. That means we will have to rewrite all the
  implementations in C++ of the interface that we’ve switched to
  std::function. It’s not that bad and should be done quickly, but it’s
  something to be done.
- There’s another pitfall. This kind of templated code is not shared
  among coin projects, so it’s very likely coin projects will have to
  include the djinni definition of Callback and ListCallback if they
  plan to use the callback2 type. I’ll make some tests / PoC today or
  tomorrow to ensure all of this is okay.

Relates to LLC-510, LLC-511.