### PR TITLE
enable use of optional for ios

### DIFF
--- a/src/source/ReactNativeObjcGenerator.scala
+++ b/src/source/ReactNativeObjcGenerator.scala
@@ -236,8 +236,7 @@ class ReactNativeObjcGenerator(spec: Spec, objcInterfaces : Seq[String]) extends
           }
         }
         case _ => {
-          //Fix LL-555
-          val paramType = marshal.paramType(p.ty).replaceFirst("nullable", "nonnull")
+          val paramType = marshal.paramType(p.ty)
           val findIntType = """int\d+_t""".r
           findIntType.findFirstIn(paramType) match {
             case Some(_) => Some(identity, s"(int)$localIdentity")


### PR DESCRIPTION
commit 1b985bce1e230a33bd7442416f24f202466476ce disabled
the possibility to set optional values to nil in react native code,
by not correctly following the types of the parameters in Objc
constructors.